### PR TITLE
anaconda.yaml: add polars to packages (PKG-14096)

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -3,6 +3,7 @@ upstream_sources:
   - pypi:
       identifier: polars
     packages:
+      - polars
       - polars-runtime-32
       - polars-runtime-64
       - polars-runtime-compat


### PR DESCRIPTION
Aligns `upstream_sources.packages` with recipe outputs so distro-db / feedstock_config_generator BOTH_DIFF clears for the primary metapackage.

Refs PKG-14096.

Made with [Cursor](https://cursor.com)